### PR TITLE
fix: [FE] 퀴즈 페이지 이전, 다음 버튼 svg로 수정

### DIFF
--- a/client/src/pages/quiz/Quiz.tsx
+++ b/client/src/pages/quiz/Quiz.tsx
@@ -4,6 +4,8 @@ import { SignRes } from "../../types/interface";
 import { useLoaderData, useNavigate } from "react-router-dom";
 import styles from "./quiz.module.scss";
 import { useInfoStore } from "../../store/store";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faChevronLeft, faChevronRight } from "@fortawesome/free-solid-svg-icons";
 
 const signData: SignRes[] = [
     {
@@ -142,8 +144,12 @@ export default function Quiz() {
                         onAnswer={handleAnswer}
                     />
                     <div className={`${styles.menu_btn}`}>
-                        <button onClick={handlePrev}>이전</button>
-                        <button onClick={handleNext}>다음</button>
+                        <button onClick={handlePrev}>
+                            <FontAwesomeIcon icon={faChevronLeft} size={"3x"} />
+                        </button>
+                        <button onClick={handleNext}>
+                            <FontAwesomeIcon icon={faChevronRight} size={"3x"} />
+                        </button>
                     </div>
                 </div>
             ) : (

--- a/client/src/pages/quiz/quiz.module.scss
+++ b/client/src/pages/quiz/quiz.module.scss
@@ -2,7 +2,7 @@
 
 .title {
     color: $color-primary;
-    margin-top: -40px;
+    margin-top: -50px;
 }
 
 .quiz {
@@ -10,24 +10,24 @@
     flex-direction: column;
     align-items: center;
     gap: 20px;
+    margin-top: -20px;
 }
 
 .menu_btn {
+    position: absolute;
     display: flex;
-    justify-content: space-around;
-    gap: 300px;
+    justify-content: space-between;
+    gap: 630px;
+    margin-top: 300px;
     button {
         padding: 15px;
         margin: 50px 30px;
-        box-shadow: 2px 2px 10px 2px gray;
-        width: 200px;
-        border-radius: 5px;
+        box-shadow: none;
         background-color: $color-primary;
         color: $color-second;
         &:hover {
-            background-color: $color-second;
-            color: $color-primary;
-            font-weight: 700;
+            background-color: $color-primary;
+            color: $color-second;
         }
     }
 }

--- a/client/src/pages/quiz/quizBox.module.scss
+++ b/client/src/pages/quiz/quizBox.module.scss
@@ -7,7 +7,7 @@
     align-items: center;
     gap: 20px;
     width: 800px;
-    height: 610px;
+    height: 620px;
     box-shadow: 2px 2px 10px 2px gray;
     border: 1px solid $color-second;
     background-color: $color-primary;
@@ -16,6 +16,7 @@
     video {
         margin-top: 15px;
         border-radius: 10px;
+        width: 650px;
         border: 1px solid $color-second;
     }
 }


### PR DESCRIPTION
## #️⃣ Issue 번호

close #

<br />

## 🔘 Part

-   [x] FE
-   [ ] BE
-   [ ] 기타

<br />

## 🛠 작업 내용
퀴즈 페이지 버튼 변경했습니다.
<br />

## 🎻 이미지 첨부 및 comment (선택)
![image](https://github.com/purple11-11/HandChatter/assets/125553827/3e0f342c-aa13-4ebf-b605-8ed107363955)

<br />
